### PR TITLE
Fix requiredness where missing

### DIFF
--- a/spec/definitions/InvoiceBankAccount.yaml
+++ b/spec/definitions/InvoiceBankAccount.yaml
@@ -2,6 +2,8 @@ type: object
 description: |
   Информация о банковском счете плательщика, к операциям с которым относится данный инвойс
 discriminator: accountType
+required:
+  - accountType
 properties:
   accountType:
     description: Вид банковского счета

--- a/spec/definitions/InvoiceClientInfo.yaml
+++ b/spec/definitions/InvoiceClientInfo.yaml
@@ -1,5 +1,7 @@
 description: 'Дополнительная информация о клиенте'
 type: object
+required:
+  - trustLevel
 properties:
   trustLevel:
     description: 'Надёжен ли плательщик?'

--- a/spec/definitions/PaymentMethod.yaml
+++ b/spec/definitions/PaymentMethod.yaml
@@ -1,5 +1,7 @@
 type: object
 discriminator: method
+required:
+  - method
 properties:
   method:
     description: Метод оплаты


### PR DESCRIPTION
Notably implementation expects that discriminator field is required. Make it so.